### PR TITLE
Add debug rule to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ NAME		= minishell
 CC			= cc
 # CFLAGS		= -Wall -Werror -Wextra -g -fsanitize=address
 CFLAGS = -Wall -Wextra
+MAKEFLAGS += --no-print-directory
 
 # Directories
 SRC_DIR		= src
@@ -25,27 +26,34 @@ LIBFT		= $(LIBFT_DIR)/libft.a
 all: $(NAME)
 
 $(NAME): $(LIBFT) $(OBJS)
-	$(CC) $(CFLAGS) $(OBJS) -L$(LIBFT_DIR) -lft -lreadline -o $(NAME)
+	@$(CC) $(CFLAGS) $(OBJS) -L$(LIBFT_DIR) -lft -lreadline -o $(NAME)
+	@echo "\e[93mFinished Compiling Minishell\e[0m"
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) -I$(INC_DIR) -I$(LIBFT_DIR) -c $< -o $@
+	@$(CC) $(CFLAGS) -I$(INC_DIR) -I$(LIBFT_DIR) -c $< -o $@
 
 $(LIBFT):
 	@make -C $(LIBFT_DIR)
 
-debug:
-	
+# debug rule to add a define flag which will set debug mode to true
+debug: CFLAGS += -D DEBUG=true
+debug: $(LIBFT) $(OBJS)
+	@$(CC) $(CFLAGS) $(OBJS) -L$(LIBFT_DIR) -lft -lreadline -o $(NAME)
+	@echo "\e[93mCompiled in debug mode\e[0m"
 
 clean:
 	@rm -rf $(OBJ_DIR)
 	@make -C $(LIBFT_DIR) clean
+	@echo "\e[93mCleaned\e[0m"
 
 fclean: clean
 	@rm -f $(NAME)
+	@echo "\e[93mThoroughly cleaned\e[0m"
 
 ffclean: fclean
 	@make -C $(LIBFT_DIR) fclean
+	@echo "\e[93mVERY thoroughly cleaned\e[0m"
 
 re: fclean all
 

--- a/inc/definitions.h
+++ b/inc/definitions.h
@@ -13,7 +13,9 @@
 #ifndef DEFINITIONS_H
 # define DEFINITIONS_H
 
-# define DEBUG true
+# ifndef DEBUG
+#  define DEBUG false
+# endif
 
 # define FAILURE 0
 # define SUCCESS 1

--- a/lib/libft/Makefile
+++ b/lib/libft/Makefile
@@ -41,31 +41,31 @@ OBJS = $(addprefix $(OBJ_DIR), $(SRCS:.c=.o)) $(addprefix $(OBJ_DIR), $(notdir $
 # Rules
 all: $(NAME)
 
-# Create obj directory if it doesn't exist
-$(OBJ_DIR):
-	mkdir -p $(OBJ_DIR)
-
 # Compile libft source files
-$(OBJ_DIR)%.o: $(SRC_DIR)%.c | $(OBJ_DIR)
-	$(CC) $(CFLAGS) -I$(INC_DIR) -c $< -o $@
+$(OBJ_DIR)%.o: $(SRC_DIR)%.c Makefile
+	@mkdir -p $(dir $@)
+	@$(CC) $(CFLAGS) -I$(INC_DIR) -c $< -o $@
 
 # Compile GNL source files
-$(OBJ_DIR)%.o: $(GNL_DIR)%.c | $(OBJ_DIR)
-	$(CC) $(CFLAGS) -I$(INC_DIR) -c $< -o $@
+$(OBJ_DIR)%.o: $(GNL_DIR)%.c Makefile
+	@mkdir -p $(dir $@)
+	@$(CC) $(CFLAGS) -I$(INC_DIR) -c $< -o $@
 
 # Compile Printf source files
-$(OBJ_DIR)%.o: $(PRINTF_DIR)%.c | $(OBJ_DIR)
-	$(CC) $(CFLAGS) -I$(INC_DIR) -c $< -o $@
+$(OBJ_DIR)%.o: $(PRINTF_DIR)%.c Makefile
+	@mkdir -p $(dir $@)
+	@$(CC) $(CFLAGS) -I$(INC_DIR) -c $< -o $@
 
 $(NAME): $(OBJS)
-	$(AR) $(NAME) $(OBJS)
+	@$(AR) $(NAME) $(OBJS)
+	@echo "\e[93mFinished Compiling libft\e[0m"
 
 clean:
-	$(RM) $(OBJS)
-	$(RM) -r $(OBJ_DIR)
+	@$(RM) $(OBJS)
+	@$(RM) -r $(OBJ_DIR)
 
 fclean: clean
-	$(RM) $(NAME)
+	@$(RM) $(NAME)
 
 re: fclean all
 


### PR DESCRIPTION
### Makefile
- I've added a debug rule that will set DEBUG=true when compiling with `make debug`
- I've added suppression everywhere and replaced all compilation commands with custom echos.
---
### inc/definitions
- Modified the DEBUG preprocessor to now check if the program got compiled with DEBUG set to `true`, if not it will default to `false`
---
### lib/libft/Makefile
- Same as the Makefile, I've added suppression everywhere and replaced all compilation commands with custom echos.
---
### Lessons? Future Additions?
- I thought about debug mode automatically cleaning all .o files, but decided against it as it could make compile time take longer
- Make the echos more fancy