### PR TITLE
Added additonal compile options to the Makefile to speed up workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,4 +57,12 @@ ffclean: fclean
 
 re: fclean all
 
+red: fclean debug
+
+rerun: fclean all
+	./minishell
+
+rerund: fclean debug
+	./minishell
+
 .PHONY: all clean fclean re


### PR DESCRIPTION
### Makefile

- Added the following compile rules:

1. `make red` for recompiling the code with debug mode set to `true`.
2. `make rerun` for recompiling the code and executing minishell immediately.
3. `make rerund` for recompiling the code with debug mode set to `true` and executing minishell immediately.